### PR TITLE
Add compile commands to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ RUN mix archive.install --force https://github.com/phoenixframework/archives/raw
 
 WORKDIR /app
 ADD . /app
+
+RUN mix do deps.get, deps.compile, compile

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ stand alone json api.
 * [Development](#development)
   * [Getting Started](#getting-started)
   * [Usage](#usage)
-    * [Installing Dependencies](#installing-dependencies)
     * [Environment Files](#environment-files)
     * [Running the API](#running-the-api)
     * [Running the Tests](#running-the-tests)
@@ -79,13 +78,14 @@ service you wish to run.
 $ docker-compose run -e MIX_ENV=test web mix test
 ```
 
-Another way of running tests:
+Or when your server is running with docker compose:
 
 ```bash
 $ docker-compose up
 ```
 
-Your DB and web container are now up and runnig. In another window on your *host* system:
+Your DB and web container will already be running. In another terminal on your
+*host* system:
 
 ```bash
 $ docker-compose exec web bash
@@ -93,9 +93,9 @@ root@74bcfda04bbc:/app#
 root@74bcfda04bbc:/app# MIX_ENV=test mix test
 ```
 
-Note any of the other test commands may be executed in this fashion. The main difference
-is that this method uses the already-running containers rather than starting new containers
-every time you run tests.
+*Note* any of the other test commands may be executed in this fashion. The main
+difference is that this method uses the already-running containers rather than
+starting new containers every time you run tests.
 
 #### Running the Tests with Coverage
 

--- a/README.md
+++ b/README.md
@@ -48,19 +48,16 @@ $ git init && git add . && git commit -m "Initial Commit"
 If you do wish to use Docker and Docker Compose, here are some commands you will
 find helpful.
 
-#### Installing Dependencies
-
-Installing dependencies can be performed in a one step command.
-
-```bash
-$ docker-compose run web mix do deps.get, deps.compile
-```
-
 #### Environment Files
 
 The docker compose definition is configured to reference environment variables
 from an `.envrc` file. A sample file is stored at `.envrc.sample` and the
-environment file is gitignored.
+environment file is gitignored. If you're just getting started, create an empty
+file to make Docker happy:
+
+```
+touch .envrc
+```
 
 #### Running the API
 
@@ -81,6 +78,24 @@ service you wish to run.
 ```bash
 $ docker-compose run -e MIX_ENV=test web mix test
 ```
+
+Another way of running tests:
+
+```bash
+$ docker-compose up
+```
+
+Your DB and web container are now up and runnig. In another window on your *host* system:
+
+```bash
+$ docker-compose exec web bash
+root@74bcfda04bbc:/app# 
+root@74bcfda04bbc:/app# MIX_ENV=test mix test
+```
+
+Note any of the other test commands may be executed in this fashion. The main difference
+is that this method uses the already-running containers rather than starting new containers
+every time you run tests.
 
 #### Running the Tests with Coverage
 


### PR DESCRIPTION
Why
---

- Compilation can be done during build time rather than as a separate
manual command

This change addresses the need by
---------------------------------

- Adding compile commands to `Dockerfile`
- Update README accordingly
- Also added some more tips to README on how to get into running system
and run tests

Next Steps
----------

- None